### PR TITLE
ansible-introduction | Fixed the definition of terminals for host2 and host3

### DIFF
--- a/ansible-introduction/index.json
+++ b/ansible-introduction/index.json
@@ -64,7 +64,7 @@
   },
   "environment": {
     "uilayout": "terminal",
-    "terminals": [{"name": "control", "target":"host01"},{"name":"host02","target":"host2"},{"name":"host03","target":"host3"}]
+    "terminals": [{"name": "control", "target":"host01"},{"name":"host02","target":"host02"},{"name":"host03","target":"host03"}]
   },
   "backend": {
     "imageid": "rhel8-cluster3"


### PR DESCRIPTION
- Fixed the definition of terminals for host2 and host3

Signed-off-by: Gabriela S. Soria <soria.gaby@gmail.com>