### PR TITLE
kpatch-patch name contains running kernel version

### DIFF
--- a/kpatch-apply/step2.md
+++ b/kpatch-apply/step2.md
@@ -43,7 +43,7 @@ kpatch-patch-4_18_0-193_1_2.x86_64                                 0-0.el8_2    
 From the above output, there are several different kpatch-patch patches 
 available, but only one of them is the one intended for the kernel running on 
 your system.  The one needed for your system is 
-`kpatch-patch-4_18_0-193_1_2.x86_64` because it is the latest available for
+`kpatch-patch-4_18_0-193.x86_64` because it is the same for
 the version of your kernel reported by `uname -r`, specifically, 4.18.0-193.el8.
 
 The other kpatch-patch packages listed, like `kpatch-patch-4_18_0-147.x86_64` is


### PR DESCRIPTION
kernel "4_18_0-193.x86_64" and "4_18_0-193_1_2.x86_64" is different version in context of kpatch. 
And kernel  4_18_0-193.x86_64 can only used with kpatch-patch-4_18_0-193.x86_64.
You can verify this by playing this lab's step3 (kpatch-patch-4_18_0-193.x86_64 will be installed) and a note in following link's document "8.6.1. Subscribing to the live patching stream".
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/applying-patches-with-kernel-live-patching_managing-monitoring-and-updating-the-kernel#enabling-kernel-live-patching_applying-patches-with-kernel-live-patching

Thanks,