### PR TITLE
manually shrunk some preformatted outputs

### DIFF
--- a/installing-software-yum/step2.md
+++ b/installing-software-yum/step2.md
@@ -9,18 +9,18 @@ use the `-y` option to automatically say yes to any prompts.
 
 <pre class=file>
 << OUTPUT ABRIDGED >>
-===========================================================================================================================================
- Package                    Architecture   Version                                          Repository                                Size
-===========================================================================================================================================
+================================================================================
+ Package                Architecture       Size
+================================================================================
 Upgrading:
- httpd                      x86_64         2.4.37-39.module+el8.4.0+9658+b87b2deb           rhel-8-for-x86_64-appstream-rpms         1.4 M
- httpd-filesystem           noarch         2.4.37-39.module+el8.4.0+9658+b87b2deb           rhel-8-for-x86_64-appstream-rpms          38 k
- httpd-tools                x86_64         2.4.37-39.module+el8.4.0+9658+b87b2deb           rhel-8-for-x86_64-appstream-rpms         106 k
- mod_ssl                    x86_64         1:2.4.37-39.module+el8.4.0+9658+b87b2deb         rhel-8-for-x86_64-appstream-rpms         134 k
- redhat-logos-httpd         noarch         84.4-1.el8                                       rhel-8-for-x86_64-baseos-rpms             29 k
+ httpd                      x86_64         1.4 M
+ httpd-filesystem           noarch         38 k
+ httpd-tools                x86_64         06 k
+ mod_ssl                    x86_64         134 k
+ redhat-logos-httpd         noarch         29 k
 
 Transaction Summary
-===========================================================================================================================================
+================================================================================
 Upgrade  5 Packages
 
 << OUTPUT ABRIDGED >>
@@ -67,7 +67,7 @@ Use the `list` subcommand to confirm that the package has been uninstalled:
 <pre class=file>
 << OUTPUT ABRIDGED >>
 Available Packages
-crontabs.noarch                                    1.11-17.20190603git.el8  
+crontabs.noarch              1.11-17.20190603git.el8  
 </pre>
 
 The package is now listed as _Available_ rather than _Installed_. The next

--- a/installing-software-yum/step3.md
+++ b/installing-software-yum/step3.md
@@ -8,14 +8,14 @@ The output contains transaction IDs in the first column, which are how you refer
 specific locations in the transaction history when executing rollbacks.
 
 <pre class=file>
-ID     | Command line                                                                         | Date and time    | Action(s)      | Altered
--------------------------------------------------------------------------------------------------------------------------------------------
-     7 | remove -y crontabs.noarch                                                            | 2021-06-11 18:42 | Removed        |    3 EE
-     6 | update -y httpd                                                                      | 2021-06-11 18:41 | Upgrade        |    5   
-     5 | install -y wireshark                                                                 | 2021-06-11 18:40 | Install        |   36   
-     4 | install -y gcc llvm-libs gcc-c++ cpp binutils bash-completion                        | 2021-03-11 22:22 | Install        |   13   
-     3 | install -y buildah podman wget vim emacs git sudo tmux cockpit ca-certificates httpd | 2021-03-11 22:21 | I, U           |  216   
-     2 | install -y rsync                                                                     | 2021-03-11 22:20 | Install        |    1   
+ID     | Command                  | Date and time    | Action(s)  | Altered
+--------------------------------------------------------------------------------
+     7 | remove -y crontabs.noarch| 2021-06-11 18:42 | Removed    |    3 EE
+     6 | update -y httpd          | 2021-06-11 18:41 | Upgrade    |    5   
+     5 | install -y wireshark     | 2021-06-11 18:40 | Install    |   36   
+     4 | install -y gcc llvm-libs | 2021-03-11 22:22 | Install    |   13   
+     3 | install -y buildah       | 2021-03-11 22:21 | I, U       |  216   
+     2 | install -y rsync         | 2021-03-11 22:20 | Install    |    1   
      1 |     
 </pre>
 


### PR DESCRIPTION
Reduced excessive output width since katacoda does not use the scroll bar formatting all of the time