### PR TITLE
Made proofread modifications

### DIFF
--- a/installing-software-yum/step1.md
+++ b/installing-software-yum/step1.md
@@ -17,10 +17,12 @@ this application was picked simply because it serves as a good test subject for
 the upcoming examples.
 
 
-`yum install -y wireshark`{{execute}}
+`yum -y install wireshark`{{execute}}
 
 >_Note:_ The `-y` option will automatically answer yes to any prompts during the
-installation.
+installation. Using this option is not best practice when installing software
+on your own system, but it is useful for streamlining some operations in
+this lab.
 
 This installation generates a large output, so here is a high level
 summary of what each section means. The first section shows all of the packages
@@ -38,8 +40,7 @@ flac-libs
 << OUTPUT ABRIDGED >>
 </pre>
 
-The next section of the output shows the total amount of memory required for the
-install, and then a verification status for each dependent package. In this case,
+The next section of the output shows a verification status for each dependent package. In this case,
 YUM made sure that 36 other packages were up to date.
 
 <pre class=file>

--- a/installing-software-yum/step2.md
+++ b/installing-software-yum/step2.md
@@ -1,11 +1,31 @@
 # Updating a package
 
-If you wish to check whether or not a particular package is up to date, the
-`update` subcommand will check for and install available updates. Specifying a
-package name will constrain this operation to only look for that package. Once again,
-use the `-y` option to automatically say yes to any prompts.
+The `list` subcommand is useful for finding out which packages have available
+updates on the system.
 
-`yum update -y bash`{{execute}}
+`yum list updates`{{execute}}
+
+<pre class=file>
+<< OUTPUT ABRIDGED >>
+Available Upgrades
+bash.x86_64              4.4.20-1.el8_4                             rhel-8-for-x86_64-baseos-rpms
+bind-export-libs.x86_64  32:9.11.26-4.el8_4                         rhel-8-for-x86_64-baseos-rpms
+buildah.x86_64           1.19.7-2.module+el8.4.0+11311+9da8acfb     rhel-8-for-x86_64-appstream-rpms
+<< OUTPUT ABRIDGED >>
+</pre>
+
+Many packages on this system have updates available. Specifying a
+package name with `yum update` will constrain this operation to only look
+for that package.
+
+>_NOTE:_ If you instead want to make sure your entire system is up to date,
+running `yum update` without any other arguments apply updates for all
+packages on your system (including YUM itself).
+
+For this example, just update the __bash__ package. Once again, use the `-y`
+option to automatically say yes to any prompts for the purposes of this lab.
+
+`yum -y update bash`{{execute}}
 
 <pre class=file>
 << OUTPUT ABRIDGED >>
@@ -27,43 +47,44 @@ with `update`. The difference between these two subcommands is that `upgrade` wi
 remove any obsolete packages from the system. Often the configuration for YUM
 is such that these subcommands will both carry out the `upgrade` operation.  
 
-If you instead want to make sure your entire system is up to date, running
-`yum update` without any other arguments will check for updates for all
-packages on your system (including YUM itself).
-
 # Removing a package
 
 Removing a package follows the same theme of simplicity.
 
-`yum remove -y crontabs.noarch`{{execute}}
+`yum -y remove httpd`{{execute}}
 
 The extensive output shows you information about which dependent RPMs were
 removed as part of this transaction.
 
 <pre class=file>
 << OUTPUT ABRIDGED >>
-Running transaction
-  Preparing
-  Erasing          : crontabs-1.11 16.20150630git.el8.noarch
-warning: /etc/crontab saved as /etc/crontab.rpmsave
+Removing:
+ httpd            x86_64 2.4.37-39.module+el8.4.0+9658+b87b2deb
+
+Removing dependent packages:
+ mod_ssl          x86_64 1:2.4.37-39.module+el8.4.0+9658+b87b2deb
+
+Removing unused dependencies:
+ apr              x86_64 1.6.3-11.el8
+
 << OUTPUT ABRIDGED >>
 
 Removed:
-  cronie-1.5.2-4.el8.x86_64             cronie-anacron-1.5.2-4.el8.x86_64             crontabs-1.11-16.20150630git.el8.noarch     
+  httpd-2.4.37-39.module+el8.4.0+9658+b87b2deb.x86_64               
+  httpd-filesystem-2.4.37-39.module+el8.4.0+9658+b87b2deb.noarch    
+  httpd-tools-2.4.37-39.module+el8.4.0+9658+b87b2deb.x86_64  
 
 Complete!
 </pre>
 
-Another notable portion of the output above is that YUM automatically
-stored the contents of `/etc/crontab` in a backup file, `/etc/crontab.rpmsave`.
 Use the `list` subcommand to confirm that the package has been uninstalled:
 
-`yum list crontabs`{{execute}}
+`yum list httpd`{{execute}}
 
 <pre class=file>
 << OUTPUT ABRIDGED >>
 Available Packages
-crontabs.noarch              1.11-17.20190603git.el8  
+httpd.x86_64 2.4.37-39.module+el8.4.0+9658+b87b2deb
 </pre>
 
 The package is now listed as _Available_ rather than _Installed_. The next

--- a/installing-software-yum/step3.md
+++ b/installing-software-yum/step3.md
@@ -10,7 +10,7 @@ specific locations in the transaction history when executing rollbacks.
 <pre class=file>
 ID| Command                  | Date and time    | Action(s)| Altered
 ------------------------------------------------------------------
-7 | remove -y crontabs.noarch| 2021-06-11 18:42 | Removed  | 3
+7 | remove -y httpd          | 2021-06-11 18:42 | Removed  | 3
 6 | update -y bash           | 2021-06-11 18:41 | Upgrade  | 1   
 5 | install -y wireshark     | 2021-06-11 18:40 | Install  | 36   
 4 | install -y gcc llvm-libs | 2021-03-11 22:22 | Install  | 13   
@@ -24,10 +24,11 @@ install or update a package, as it cleans up all of the dependencies associated
 with the package. Rollback the state of your system to before you uninstalled
 __crontabs__:
 
-`yum history rollback last-1 -y`{{execute}}
+`yum -y history rollback 6 `{{execute}}
 
->_NOTE:_ The `last-1` keyword is used here to specify that the rollback
-the state of the system to how it was before the most recent transaction.
+>_NOTE:_ The number 6 here is used here to specify that the rollback
+the state of the system to how it was at transaction ID 6, or before you
+removed __httpd__.
 You can use other relative offsets, such as `last-3`, or you can use absolute
 transaction IDs. For example, `yum history rollback 2` would rollback to the
 transaction where __rsync__ was installed.
@@ -35,12 +36,18 @@ transaction where __rsync__ was installed.
 <pre class=file>
 << OUTPUT ABRIDGED >>
 Installed:
-  cronie-1.5.2-4.el8.x86_64             cronie-anacron-1.5.2-4.el8.x86_64             crontabs-1.11-16.20150630git.el8.noarch            
+  apr-1.6.3-11.el8.x86_64                                           
+  apr-util-1.6.1-6.el8.x86_64                                       
+  apr-util-bdb-1.6.1-6.el8.x86_64                                   
+  apr-util-openssl-1.6.1-6.el8.x86_64                               
+  httpd-2.4.37-39.module+el8.4.0+9658+b87b2deb.x86_64               
+  httpd-filesystem-2.4.37-39.module+el8.4.0+9658+b87b2deb.noarch          
 
 Complete!
 </pre>
 
-This command reinstalled the RPMs that are part of the __crontabs__ package,
+This command reinstalled the RPMs that are part of __httpd__ (including
+all dependencies),
 restoring the system state to how it was before the previous transaction.
 
 There are many more subcommands that you can use to customize how YUM behaves.

--- a/installing-software-yum/step5.md
+++ b/installing-software-yum/step5.md
@@ -18,7 +18,7 @@ missing     /usr/share/icons/hicolor/256x256/apps/wireshark.png
 Now that you have seen there is a missing file, reinstall the Wireshark
 package to return it to its proper state:
 
-`yum reinstall -y wireshark`{{execute}}
+`yum -y reinstall wireshark`{{execute}}
 
 <pre class=file>
 << OUTPUT ABRIDGED >>
@@ -37,3 +37,21 @@ Check that __wireshark.png__ has been restored:
 <pre class=file>
 fedora-logo-icon.png  wireshark.png
 </pre>
+
+The command `rpm -V` is useful for more than just finding missing files.
+This command can inform the user if any files have changed since installation.
+To test this out, run the validation command on the PAM package.
+
+`rpm -V pam`{{execute}}
+
+<pre class=file>
+S.5....T.  c /etc/pam.d/password-auth
+S.5....T.  c /etc/pam.d/system-auth
+</pre>
+
+This query returns two files with unexpected criteria, __password-auth__ and
+__system-auth__. The first column of this output tells you that both of these
+files have an unexpected size, checksum, and
+timestamp. Both of these files are configuration files, so it makes sense
+that they would be modified after installation to suit the purpose of this
+particular system.


### PR DESCRIPTION
- standardized `-y` formatting
- removed erroneous reference to package size 
- added warning against using `-y` in everyday operations
- added `yum list updates` to step 2
- changed package being removed from `cron` to `httpd`
- used absolute ID in history instead of relative
- expanded `rpm -V` discussion to include a second example